### PR TITLE
Refactor

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
-from typing import List, Literal, Optional
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel, Field
+from typing import Optional
+from fastapi import FastAPI, HTTPException
 from cat import Cat
 
 app = FastAPI()

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def update_cat(cat_id: int, cat_for_update: Cat):
 def get_cat_by_id(cat_id: int):
     return cats.get(cat_id, {})
 
-@app.get('/cats/')
+@app.get('/cats')
 def get_cat_by_name(cat_name: Optional[str] = None):
     if cat_name is None:
         return cats


### PR DESCRIPTION
Simplified cat object storage

Since we have a `Cat(BaseModel)`model defined, why not use it? We define `cats: dict[int, Cats]`-  a dict that should store pairs of IDs and their corresponding `Cat` objects. No need to store raw `dict`s of cats. 

This way, we 1) retain the functionality of pydantic's models 2) do not need to convert dicts to models, and back

It should be noted that FastAPI automatically serializes `BaseModel`s into JSON on `return`.