### PR TITLE
Refactor

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,5 @@
-from typing import List, Literal, Optional
-from fastapi import FastAPI, HTTPException, Query
-from pydantic import BaseModel, Field
+from typing import Optional
+from fastapi import FastAPI, HTTPException
 from cat import Cat
 
 app = FastAPI()

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ def update_cat(cat_id: int, cat_for_update: Cat):
 def get_cat_by_id(cat_id: int):
     return cats.get(cat_id, {})
 
-@app.get('/cats/')
+@app.get('/cats')
 def get_cat_by_name(cat_name: Optional[str] = None):
     if cat_name is None:
         return cats


### PR DESCRIPTION
- Organized imports
- Removed redundant `/` in `GET /cats`. This `/` causes errors since `localhost:8000/cats` is actually different compared to `localhost:8000/cats/` *(notice the `/` on the end)*